### PR TITLE
Use a proxy cache_lock for less load on gna.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ location / {
     proxy_cache_use_stale  off;
     proxy_cache_valid 5s;
 
+    # Also use a Cache lock (only one request going to gna.py at a time)
+    proxy_cache_lock on;
 }
 
 ~~~


### PR DESCRIPTION
This ensures, that only one request at a time will be passed to gna.py. If the cache is not valid, only one request will get passed through to gna.py. Others arriving while the origin request has been active, will be served from the same request, which is currently in line.